### PR TITLE
Update package validation baseline to 0.1.0-preview.0.1.3

### DIFF
--- a/src/Pure.Primitives.Abstractions.Serialization.System/Pure.Primitives.Abstractions.Serialization.System.csproj
+++ b/src/Pure.Primitives.Abstractions.Serialization.System/Pure.Primitives.Abstractions.Serialization.System.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.0.1.2</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.0.1.3</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Primitives.Abstractions.Serialization.System</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.0.1.2` to `0.1.0-preview.0.1.3` following the successful publish.